### PR TITLE
Add Extra field back to predefined values interface

### DIFF
--- a/administration/preValues.php
+++ b/administration/preValues.php
@@ -20,6 +20,7 @@ $aFields = array(
     'Value'  => _t('_adm_pvalues_help_value'),
     'LKey'   => _t('_adm_pvalues_help_lkey'),
     'LKey2'  => _t('_adm_pvalues_help_lkey2'),
+    'Extra'  => _t('_adm_pvalues_help_extra'),
 );
 
 if(bx_get('popup') !== false && (int)bx_get('popup') == 1) {


### PR DESCRIPTION
I had plans for Extra field. Having it built-in to Predefined Values Builder saves having to create a custom interface. Even with the Extra field it still saves predefined countries when max_input_vars is set to default of 1000.