### PR TITLE
Remove multiple delete buttons from album page

### DIFF
--- a/modules/boonex/files/install/sql/uninstall.sql
+++ b/modules/boonex/files/install/sql/uninstall.sql
@@ -49,7 +49,7 @@ DELETE FROM `sys_stat_site` WHERE `Name` = 'shf';
 
 DELETE FROM `sys_account_custom_stat_elements` WHERE `Label` = '_bx_files';
 
-DELETE FROM `sys_objects_actions` WHERE `Type` IN ('bx_files', 'bx_files_title');
+DELETE FROM `sys_objects_actions` WHERE `Type` IN ('bx_files', 'bx_files_title', 'bx_files_album');
 
 DELETE `sys_acl_actions`, `sys_acl_matrix` FROM `sys_acl_actions`, `sys_acl_matrix` WHERE `sys_acl_matrix`.`IDAction` = `sys_acl_actions`.`ID` AND `sys_acl_actions`.`Name` LIKE 'files%';
 DELETE FROM `sys_acl_actions` WHERE `Name` LIKE 'files%';

--- a/modules/boonex/photos/install/sql/uninstall.sql
+++ b/modules/boonex/photos/install/sql/uninstall.sql
@@ -52,7 +52,7 @@ DELETE FROM `sys_stat_site` WHERE `Name` = 'phs';
 
 DELETE FROM `sys_account_custom_stat_elements` WHERE `Label` = '_bx_photos';
 
-DELETE FROM `sys_objects_actions` WHERE `Type` IN ('bx_photos', 'bx_photos_title');
+DELETE FROM `sys_objects_actions` WHERE `Type` IN ('bx_photos', 'bx_photos_title', 'bx_photos_album');
 
 DELETE `sys_acl_actions`, `sys_acl_matrix` FROM `sys_acl_actions`, `sys_acl_matrix` WHERE `sys_acl_matrix`.`IDAction` = `sys_acl_actions`.`ID` AND `sys_acl_actions`.`Name` LIKE 'photos%';
 DELETE FROM `sys_acl_actions` WHERE `Name` LIKE 'photos%';

--- a/modules/boonex/sounds/install/sql/uninstall.sql
+++ b/modules/boonex/sounds/install/sql/uninstall.sql
@@ -51,7 +51,7 @@ DELETE FROM `sys_stat_site` WHERE `Name` = 'pmu';
 
 DELETE FROM `sys_account_custom_stat_elements` WHERE `Label` = '_bx_sounds';
 
-DELETE FROM `sys_objects_actions` WHERE `Type` IN ('bx_sounds', 'bx_sounds_title');
+DELETE FROM `sys_objects_actions` WHERE `Type` IN ('bx_sounds', 'bx_sounds_title', 'bx_sounds_album');
 
 DELETE `sys_acl_actions`, `sys_acl_matrix` FROM `sys_acl_actions`, `sys_acl_matrix` WHERE `sys_acl_matrix`.`IDAction` = `sys_acl_actions`.`ID` AND `sys_acl_actions`.`Name` LIKE 'sounds%';
 DELETE FROM `sys_acl_actions` WHERE `Name` LIKE 'sounds%';

--- a/modules/boonex/videos/install/sql/uninstall.sql
+++ b/modules/boonex/videos/install/sql/uninstall.sql
@@ -51,7 +51,7 @@ DELETE FROM `sys_stat_site` WHERE `Name` = 'pvi';
 
 DELETE FROM `sys_account_custom_stat_elements` WHERE `Label` = '_bx_videos';
 
-DELETE FROM `sys_objects_actions` WHERE `Type` IN ('bx_videos', 'bx_videos_title');
+DELETE FROM `sys_objects_actions` WHERE `Type` IN ('bx_videos', 'bx_videos_title', 'bx_videos_album');
 
 DELETE `sys_acl_actions`, `sys_acl_matrix` FROM `sys_acl_actions`, `sys_acl_matrix` WHERE `sys_acl_matrix`.`IDAction` = `sys_acl_actions`.`ID` AND `sys_acl_actions`.`Name` LIKE 'videos%';
 DELETE FROM `sys_acl_actions` WHERE `Name` LIKE 'videos%';


### PR DESCRIPTION
When files, photos, sounds, and videos are uninstalled and reinstalled, multiple delete buttons appear on album page.