### PR TITLE
Login form has close link even when it's not a popup

### DIFF
--- a/inc/admin.inc.php
+++ b/inc/admin.inc.php
@@ -22,7 +22,7 @@ function login_form($text = "", $member = 0, $bAjaxMode = false, $sLoginFormPara
     }
 
     if ($bAjaxMode)
-        $sLoginFormParams .= ' no_join_text';
+        $sLoginFormParams .= ' no_join_text add_close_link';
 
     $sLoginFormContent = getMemberLoginFormCode('login_box_form', $sLoginFormParams);
 

--- a/inc/design.inc.php
+++ b/inc/design.inc.php
@@ -282,8 +282,8 @@ function getMemberJoinFormCode($sParams = '')
 	if(getParam('reg_by_inv_only') == 'on' && getID($_COOKIE['idFriend']) == 0)
 		return MsgBox(_t('_registration by invitation only'));
 
-	$sCodeBefore = '';
-    $sCodeAfter = $GLOBALS['oSysTemplate']->parseHtmlByName('join_form_code_after.html', array());
+    $sCodeBefore = $GLOBALS['oSysTemplate']->parseHtmlByName('login_join_close.html', array());
+    $sCodeAfter = '';
 
 	bx_import("BxDolJoinProcessor");
     $oJoin = new BxDolJoinProcessor();
@@ -359,7 +359,7 @@ function getMemberLoginFormCode($sID = 'member_login_form', $sParams = '')
 				'tr_attrs' => array(
 					'class' => 'bx-form-element-forgot'
 				),
-				'content' => '<a href="' . BX_DOL_URL_ROOT . 'forgot.php">' . _t('_forgot_your_password') . '?</a> ' . _t('_or') . ' <a href="javascript:void(0)" onclick="javascript:hidePopupLoginForm()">' . _t('_Close') . '</a>',
+                'content' => '<a href="' . BX_DOL_URL_ROOT . 'forgot.php">' . _t('_forgot_your_password') . '?</a>',
 			)
         ),
     );
@@ -367,7 +367,7 @@ function getMemberLoginFormCode($sID = 'member_login_form', $sParams = '')
     $oForm = new BxTemplFormView($aForm);
 
     bx_import('BxDolAlerts');
-    $sCustomHtmlBefore = '';
+    $sCustomHtmlBefore = (strpos($sParams, 'add_close_link') === false) ? '' : $GLOBALS['oSysTemplate']->parseHtmlByName('login_join_close.html', array());
     $sCustomHtmlAfter = '';
     $oAlert = new BxDolAlerts('profile', 'show_login_form', 0, 0, array('oForm' => $oForm, 'sParams' => &$sParams, 'sCustomHtmlBefore' => &$sCustomHtmlBefore, 'sCustomHtmlAfter' => &$sCustomHtmlAfter));
     $oAlert->alert();

--- a/inc/js/functions.js
+++ b/inc/js/functions.js
@@ -884,9 +884,6 @@ function showPopupLoginFormOld() {
 function showPopupJoinForm() {
 	showPopupLoginForm(1);
 }
-function hidePopupJoinForm() {
-	hidePopupLoginForm();
-}
 
 function showPopupLoginForm(iActiveTab) {
 	var sPopupId = 'login_div';
@@ -924,7 +921,8 @@ function showPopupLoginForm(iActiveTab) {
         );
     }
 }
-function hidePopupLoginForm() {
+
+function hidePopupLoginJoinForm() {
 	$('#login_div').dolPopup({});
 }
 

--- a/templates/base/css/general.css
+++ b/templates/base/css/general.css
@@ -324,7 +324,10 @@ div.sys-form-login-join .sys-flj-content a.bx-btn:visited {
 }
 
 div.sys-form-login-join .sys-flj-close {
-	text-align: center;
+	text-align: right;
+}
+div.sys-form-login-join .login-box-form .sys-flj-close {
+	margin-bottom: 0;
 }
 
 /*--- Login Join Auth Section ---*/

--- a/templates/base/join_form_code_after.html
+++ b/templates/base/join_form_code_after.html
@@ -1,3 +1,0 @@
-<div class="sys-flj-close bx-def-margin-top">
-	<a href="javascript:void(0)" onclick="javascript:hidePopupJoinForm()"><bx_text:_Close /></a>
-</div>

--- a/templates/base/login_join_close.html
+++ b/templates/base/login_join_close.html
@@ -1,0 +1,3 @@
+<div class="sys-flj-close bx-def-margin-bottom">
+	<a href="javascript:void(0)" onclick="javascript:hidePopupLoginJoinForm()"><bx_text:_Close /></a>
+</div>


### PR DESCRIPTION
Login form should not have a close link unless it's a popup. And the user shouldn't have to scroll to get to the close link on the join form on smaller screens.