### PR TITLE
Changes as per comments in #325

### DIFF
--- a/inc/admin.inc.php
+++ b/inc/admin.inc.php
@@ -22,25 +22,26 @@ function login_form($text = "", $member = 0, $bAjaxMode = false, $sLoginFormPara
     }
 
     if ($bAjaxMode)
-        $sLoginFormParams .= ' no_join_text add_close_link';
+        $sLoginFormParams .= ' no_join_text';
 
     $sLoginFormContent = getMemberLoginFormCode('login_box_form', $sLoginFormParams);
 
     if($bAjaxMode) {
-    	$iDesignBox = 1;
-    	$sContent = $sLoginFormContent;
+        $iDesignBox = 1;
+        $sContent = $sLoginFormContent;
+        $sCaptionItems = '<div class="dbTopMenu"><i class="bx-popup-element-close sys-icon times"></i></div>';
 
-    	$sJoinFormContent = getMemberJoinFormCode();
-    	if(!empty($sJoinFormContent)) {
-    		$iDesignBox = 3;
-			$sContent = $GLOBALS['oSysTemplate']->parseHtmlByName('login_join_popup.html', array(
-				'login_form' => $sLoginFormContent,
-				'join_form' => $sJoinFormContent
-			));
-    	}
+        $sJoinFormContent = getMemberJoinFormCode();
+        if(!empty($sJoinFormContent)) {
+            $iDesignBox = 3;
+            $sContent = $GLOBALS['oSysTemplate']->parseHtmlByName('login_join_popup.html', array(
+                'login_form' => $sLoginFormContent,
+                'join_form' => $sJoinFormContent,
+                'top_menu' => $sCaptionItems,
+            ));
+        }
 
-		$sCaption = _t('_Login');
-    	$sCaptionItems = '<div class="dbTopMenu"><i class="bx-popup-element-close sys-icon times"></i></div>';
+        $sCaption = _t('_Login');
         $sMemberLoginFormAjx = $GLOBALS['oFunctions']->transBox(
             DesignBoxContent($sCaption, $sContent, $iDesignBox, $sCaptionItems), true
         );

--- a/inc/design.inc.php
+++ b/inc/design.inc.php
@@ -282,7 +282,7 @@ function getMemberJoinFormCode($sParams = '')
 	if(getParam('reg_by_inv_only') == 'on' && getID($_COOKIE['idFriend']) == 0)
 		return MsgBox(_t('_registration by invitation only'));
 
-    $sCodeBefore = $GLOBALS['oSysTemplate']->parseHtmlByName('login_join_close.html', array());
+    $sCodeBefore = '';
     $sCodeAfter = '';
 
 	bx_import("BxDolJoinProcessor");
@@ -367,7 +367,7 @@ function getMemberLoginFormCode($sID = 'member_login_form', $sParams = '')
     $oForm = new BxTemplFormView($aForm);
 
     bx_import('BxDolAlerts');
-    $sCustomHtmlBefore = (strpos($sParams, 'add_close_link') === false) ? '' : $GLOBALS['oSysTemplate']->parseHtmlByName('login_join_close.html', array());
+    $sCustomHtmlBefore = '';
     $sCustomHtmlAfter = '';
     $oAlert = new BxDolAlerts('profile', 'show_login_form', 0, 0, array('oForm' => $oForm, 'sParams' => &$sParams, 'sCustomHtmlBefore' => &$sCustomHtmlBefore, 'sCustomHtmlAfter' => &$sCustomHtmlAfter));
     $oAlert->alert();

--- a/inc/js/functions.js
+++ b/inc/js/functions.js
@@ -922,10 +922,6 @@ function showPopupLoginForm(iActiveTab) {
     }
 }
 
-function hidePopupLoginJoinForm() {
-	$('#login_div').dolPopup({});
-}
-
 function showPopupAnyHtml(sUrl, oCustomOptions) {
     var oPopupOptions = {};
 

--- a/templates/base/css/general.css
+++ b/templates/base/css/general.css
@@ -286,6 +286,11 @@ div.sys-form-login-join ul.sys-flj-navigation li.ui-tabs-active a {
 	text-align: center;
 }
 
+div#tabs-login .dbTopMenu,
+div#tabs-join .dbTopMenu {
+    text-align: right;
+}
+
 div.login_ajax_wrap div.sys-form-login-join .form_advanced_wrapper {
 	overflow: visible;
 }
@@ -321,13 +326,6 @@ div.sys-form-login-join .sys-flj-content a.bx-btn:active,
 div.sys-form-login-join .sys-flj-content a.bx-btn:visited {
 	text-decoration: none;
 	color: #333333;
-}
-
-div.sys-form-login-join .sys-flj-close {
-	text-align: right;
-}
-div.sys-form-login-join .login-box-form .sys-flj-close {
-	margin-bottom: 0;
 }
 
 /*--- Login Join Auth Section ---*/

--- a/templates/base/login_join_close.html
+++ b/templates/base/login_join_close.html
@@ -1,3 +1,0 @@
-<div class="sys-flj-close bx-def-margin-bottom">
-	<a href="javascript:void(0)" onclick="javascript:hidePopupLoginJoinForm()"><bx_text:_Close /></a>
-</div>

--- a/templates/base/login_join_popup.html
+++ b/templates/base/login_join_popup.html
@@ -3,6 +3,6 @@
 		<li><a href="#tabs-login"><bx_text:_Login /></a></li>
 		<li><a href="#tabs-join"><bx_text:_Join_now /></a></li>
 	</ul>
-	<div id="tabs-login">__login_form__</div>
-	<div id="tabs-join">__join_form__</div>
+	<div id="tabs-login">__top_menu____login_form__</div>
+	<div id="tabs-join">__top_menu____join_form__</div>
 </div>


### PR DESCRIPTION
I used the `x` icon and moved it above the Facebook Connect. I didn't tweak the CSS. It's got a slightly tighter bottom spacing than your screenshot and it's black. Most of the other close icons are black even in EVO unless it uses an anchor and gets that colour.

Not sure if you really wanted it blue or not. If so, it should probably only be made blue in EVO CSS.

Here's a screenshot.
![temp3](https://cloud.githubusercontent.com/assets/3107215/13166778/195b58d2-d6a2-11e5-8a8e-7ad4c72b6683.png)
