### PR TITLE
Add a login-only option to the service menu

### DIFF
--- a/inc/admin.inc.php
+++ b/inc/admin.inc.php
@@ -27,11 +27,11 @@ function login_form($text = "", $member = 0, $bAjaxMode = false, $sLoginFormPara
     $sLoginFormContent = getMemberLoginFormCode('login_box_form', $sLoginFormParams);
 
     if($bAjaxMode) {
-        $iDesignBox = 1;
+        $iDesignBox = 11;
         $sContent = $sLoginFormContent;
         $sCaptionItems = '<div class="dbTopMenu"><i class="bx-popup-element-close sys-icon times"></i></div>';
 
-        $sJoinFormContent = getMemberJoinFormCode();
+        $sJoinFormContent = empty($_REQUEST['add_join_form']) ? '' : getMemberJoinFormCode();
         if(!empty($sJoinFormContent)) {
             $iDesignBox = 3;
             $sContent = $GLOBALS['oSysTemplate']->parseHtmlByName('login_join_popup.html', array(

--- a/inc/js/functions.js
+++ b/inc/js/functions.js
@@ -881,11 +881,15 @@ function showPopupLoginFormOld() {
     }
 }
 
+function showPopupLoginOnlyForm() {
+    showPopupLoginForm(0, false);
+}
+
 function showPopupJoinForm() {
 	showPopupLoginForm(1);
 }
 
-function showPopupLoginForm(iActiveTab) {
+function showPopupLoginForm(iActiveTab, bJoinForm) {
 	var sPopupId = 'login_div';
 	var oPopupOptions = {
 		closeOnOuterClick: false
@@ -895,6 +899,9 @@ function showPopupLoginForm(iActiveTab) {
 
 	if(!iActiveTab)
 		iActiveTab = 0;
+
+    if (bJoinForm !== false)
+        bJoinForm = true;
 
     if ($('#' + sPopupId).length) {
     	$("#" + sContentId).tabs({active: iActiveTab});
@@ -906,7 +913,8 @@ function showPopupLoginForm(iActiveTab) {
             site_url + 'member.php',
             {
                 action: 'show_login_form',
-                relocate: String(window.location)
+                relocate: String(window.location),
+                add_join_form: bJoinForm ? 1 : 0
             },
             function() {
             	var sHref = location.href.replace(location.hash, '');

--- a/install/sql/v72.sql
+++ b/install/sql/v72.sql
@@ -182,6 +182,7 @@ CREATE TABLE `sys_menu_service` (
 INSERT INTO `sys_menu_service` (`Name`, `Caption`, `Icon`, `Link`, `Script`, `Target`, `Order`, `Visible`, `Active`, `Movable`, `Clonable`, `Editable`, `Deletable`) VALUES
 ('Join', '_sys_sm_join', 'user', '', 'showPopupJoinForm(); return false;', '', 1, 'non', 1, 3, 1, 1, 1),
 ('Login', '_sys_sm_login', 'sign-in', '', 'showPopupLoginForm(); return false;', '', 0, 'non', 0, 3, 1, 1, 1),
+('LoginOnly', '_sys_sm_login', 'sign-in', '', 'showPopupLoginOnlyForm(); return false;', '', 0, 'non', 0, 3, 1, 1, 1),
 ('Profile', '_sys_sm_profile', '', '{memberLink}|{memberNick}|change_status.php', '', '', 0, 'memb', 0, 3, 1, 1, 1),
 ('Account', '_sys_sm_account', 'tachometer', 'member.php', '', '', 1, 'memb', 1, 3, 1, 1, 1),
 ('ProfileSettings', '_sys_sm_profile_settings', 'cog', 'pedit.php?ID={memberID}', '', '', 2, 'memb', 1, 3, 1, 1, 1),


### PR DESCRIPTION
I kept the default behavior of including the join form in the popup. However, the join form is no longer included in all Ajax requests which is good because not all Ajax requests are popups. And only the popup uses the ui-tabs.

Note that this does not apply to EVO template which ignores service menu settings for non-members. I'm working on another pull request for that.