### PR TITLE
EVO service menu ignores admin settings for visitors

### DIFF
--- a/templates/base/scripts/BxBaseMenuSimple.php
+++ b/templates/base/scripts/BxBaseMenuSimple.php
@@ -64,4 +64,45 @@
 
             return $GLOBALS['oSysTemplate']->parseHtmlByName('extra_' . $this->sName . '_menu.html', array('bx_repeat:items' => $aTmplVars));
         }
+
+        function getItemsArray($iLimit=1)
+        {
+            if(empty($this->aItems))
+                $this->load();
+
+            if(isset($GLOBALS['bx_profiler']))
+                $GLOBALS['bx_profiler']->beginMenu(ucfirst($this->sName) . ' Menu');
+
+            $iCount = 0;
+            $aTmplVars = array();
+            foreach ($this->aItems as $aItem) {
+                if (!$this->checkToShow($aItem))
+                    continue;
+
+                $iCount++;
+                if ($iCount > $iLimit)
+                    break;
+
+                list($aItem['Link']) = explode('|', $aItem['Link']);
+
+                $aItem['Caption'] = _t($this->replaceMetas($aItem['Caption']));
+                $aItem['Link'] = $this->replaceMetas($aItem['Link']);
+                $aItem['Script'] = $this->replaceMetas($aItem['Script']);
+
+                $aTmplVars[] = array(
+                    'name' => $aItem['Name'],
+                    'caption' => $aItem['Caption'],
+                    'caption_attr' => bx_html_attribute($aItem['Caption']),
+                    'icon' => $aItem['Icon'],
+                    'link' => $aItem['Script'] ? 'javascript:void(0)' : $this->oPermalinks->permalink($aItem['Link']),
+                    'script' => $aItem['Script'] ? 'onclick="' . $aItem['Script'] . '"' : null,
+                    'target' => $aItem['Target'] ? 'target="_blank"' : null
+                );
+            }
+
+            if(isset($GLOBALS['bx_profiler']))
+                $GLOBALS['bx_profiler']->endMenu(ucfirst($this->sName) . ' Menu');
+
+            return $aTmplVars;
+        }
     }

--- a/templates/tmpl_evo/extra_service_menu_wrapper.html
+++ b/templates/tmpl_evo/extra_service_menu_wrapper.html
@@ -1,13 +1,13 @@
 <div class="sys-service-menu-wrp">
 	<div class="sys-service-menu">
 		<bx_if:show_for_visitor>
-			<div class="sys-sm-item sys-smi-join bx-def-margin-sec-left-auto" onclick="javascript:showPopupJoinForm()">
+			<div class="sys-sm-item sys-smi-join bx-def-margin-sec-left-auto" __script__">
 				<div class="sys-sm-profile">
 					<span class="sys-smp-thumbnail">
-						<i class="sys-icon user"></i>
+						<i class="sys-icon __icon__"></i>
 					</span>
 					<span class="sys-smp-title bx-def-margin-sec-left bx-def-margin-right">
-						<bx_text:_sys_sm_join_or_login />
+						__caption__
 					</span>
 				</div>
 	        </div>

--- a/templates/tmpl_evo/scripts/BxTemplFunctions.php
+++ b/templates/tmpl_evo/scripts/BxTemplFunctions.php
@@ -20,65 +20,76 @@
         	)); 
         }
 
-	    function genSiteServiceMenu()
-	    {
-	    	$bLogged = isLogged();
+        function genSiteServiceMenu()
+        {
+            $bLogged = isLogged();
 
-	    	$aMenuItem = array();
-	    	$sMenuPopupId = '';
-	    	$sMenuPopupContent = '';
-	    	if($bLogged) {
-	    		bx_import('BxTemplMenuService');
-	        	$oMenu = new BxTemplMenuService();
+            $aMenuItem = array();
+            $sMenuPopupId = '';
+            $sMenuPopupContent = '';
+            $bShowVisitor = false;
 
-	        	if($oMenu->aMenuInfo['memberID'] != 0)
-	        		$aProfile = getProfileInfo($oMenu->aMenuInfo['memberID']);
+            bx_import('BxTemplMenuService');
+            $oMenu = new BxTemplMenuService();
 
-	        		$sThumbSetting = getParam('sys_member_info_thumb_icon');
+            if($bLogged) {
+                $aProfile = getProfileInfo($oMenu->aMenuInfo['memberID']);
 
-		        	bx_import('BxDolMemberInfo');
-			        $o = BxDolMemberInfo::getObjectInstance($sThumbSetting);
-			        $sThumbUrl = $o ? $o->get($aProfile) : '';
+                $sThumbSetting = getParam('sys_member_info_thumb_icon');
+                bx_import('BxDolMemberInfo');
 
-			        $o = BxDolMemberInfo::getObjectInstance($sThumbSetting . '_2x');
-			        $sThumbTwiceUrl = $o ? $o->get($aProfile) : '';
+                $o = BxDolMemberInfo::getObjectInstance($sThumbSetting);
+                $sThumbUrl = $o ? $o->get($aProfile) : '';
+                $bThumb = !empty($sThumbUrl);
 
-			        if(!$sThumbTwiceUrl)
-			        	$sThumbTwiceUrl = $sThumbUrl;
+                $o = BxDolMemberInfo::getObjectInstance($sThumbSetting . '_2x');
+                $sThumbTwiceUrl = $o ? $o->get($aProfile) : '';
+                if(!$sThumbTwiceUrl)
+                    $sThumbTwiceUrl = $sThumbUrl;
 
-					$bThumb = !empty($sThumbUrl);
-		        	$aMenuItem = array(
-		        		'bx_if:show_fu_thumb_image' => array(
-		        			'condition' => $bThumb,
-		        			'content' => array(
-		        				'image' => $sThumbUrl,
-		        				'image_2x' => $sThumbTwiceUrl,
-		        			)
-		        		),
-		        		'bx_if:show_fu_thumb_icon' => array(
-		        			'condition' => !$bThumb,
-		        			'content' => array()
-		        		),
-		        		'thumbnail' => get_member_icon($oMenu->aMenuInfo['memberID']),
-						'title' => getNickName($oMenu->aMenuInfo['memberID'])
-	    			);
+                $aMenuItem = array(
+                    'bx_if:show_fu_thumb_image' => array(
+                        'condition' => $bThumb,
+                        'content' => array(
+                            'image' => $sThumbUrl,
+                            'image_2x' => $sThumbTwiceUrl,
+                        )
+                    ),
+                    'bx_if:show_fu_thumb_icon' => array(
+                        'condition' => !$bThumb,
+                        'content' => array()
+                    ),
+                    'title' => getNickName($oMenu->aMenuInfo['memberID'])
+                );
 
-	        	$sMenuPopupId = 'sys-service-menu-' . mktime();
-	    		$sMenuPopupContent = $this->transBox($oMenu->getCode());
-	    	}
+                $sMenuPopupId = 'sys-service-menu-' . mktime();
+                $sMenuPopupContent = $this->transBox($oMenu->getCode());
+            }
+            else {
+                $aItems = $oMenu->getItemsArray();
+                if (!empty($aItems)) {
+                    $bShowVisitor = true;
+                    $bLoginOnly = ($aItems[0]['name'] == 'LoginOnly');
+                    $aMenuItem = array(
+                        'caption' => $bLoginOnly ? $aItems[0]['caption'] : _t('_sys_sm_join_or_login'),
+                        'icon' => $bLoginOnly ? $aItems[0]['icon'] : 'user',
+                        'script' => $aItems[0]['script'],
+                    );
+                }
+            }
 
-	    	return $GLOBALS['oSysTemplate']->parseHtmlByName('extra_service_menu_wrapper.html', array(
-	    		'bx_if:show_for_visitor' => array(
-	    			'condition' => !$bLogged,
-	    			'content' => array()
-	    		),
-	    		'bx_if:show_for_user' => array(
-	    			'condition' => $bLogged,
-	    			'content' => $aMenuItem
-	    		),
-	    		'menu_popup_id' => $sMenuPopupId,
-	    		'menu_popup_content' => $sMenuPopupContent
-	    	));
-	    }
+            return $GLOBALS['oSysTemplate']->parseHtmlByName('extra_service_menu_wrapper.html', array(
+                'bx_if:show_for_visitor' => array(
+                    'condition' => !$bLogged && $bShowVisitor,
+                    'content' => $aMenuItem,
+                ),
+                'bx_if:show_for_user' => array(
+                    'condition' => $bLogged,
+                    'content' => $aMenuItem,
+                ),
+                'menu_popup_id' => $sMenuPopupId,
+                'menu_popup_content' => $sMenuPopupContent,
+            ));
+        }
     }
     $oFunctions = new BxTemplFunctions();


### PR DESCRIPTION
The service menu is hard-coded for visitors and always makes the Join tab active even if Join item is not an active menu item.
