### PR TITLE
Provide option to hide default albums

### DIFF
--- a/inc/classes/BxDolFilesModule.php
+++ b/inc/classes/BxDolFilesModule.php
@@ -1097,7 +1097,7 @@ class BxDolFilesModule extends BxDolModule
             $this->oAlbums->addAlbum(array(
                 'caption' => $sAlbum,
                 'owner' => $iProfileId,
-                'AllowAlbumView' => $this->oAlbumPrivacy->_oDb->getDefaultValueModule($sUri, 'album_view'),
+                'AllowAlbumView' => ($sAlbum == getParam('sys_album_default_name')) ? BX_DOL_PG_HIDDEN : $this->oAlbumPrivacy->_oDb->getDefaultValueModule($sUri, 'album_view'),
             ), false);
 		}
     }


### PR DESCRIPTION
I don't use the profile cover block. The unused cover photo album is confusing for users especially because they can't delete it.

A while back, when I was experimenting, I was sure that setting the name of this default album to the same value that was set in `sys_album_default_name` actually hid it from album management. Now I can't duplicate that behavior, so I am not sure what I did at the time. However, this does seem like a simple solution to my problem.