### PR TITLE
fix: correct Occured→Occurred typo in error messages

### DIFF
--- a/administration/charts.json.php
+++ b/administration/charts.json.php
@@ -24,12 +24,12 @@ function bx_charts_get_json($sObject, $sFrom, $sTo)
 {
     $aObject = $GLOBALS['MySQL']->getRow("SELECT * FROM `sys_objects_charts` WHERE `object` = ? AND `active` = ?", [$sObject, 1]);
     if (!$aObject)
-        return json_encode(array('error' => _t('_Error Occured')));
+        return json_encode(array('error' => _t('_Error Occurred')));
 
     $iFrom = bx_charts_get_ts($sFrom);
     $iTo = bx_charts_get_ts($sTo, true);
     if (!$iFrom || !$iTo)
-        return json_encode(array('error' => _t('_Error Occured')));
+        return json_encode(array('error' => _t('_Error Occurred')));
 
     $aData = bx_charts_get_data($aObject, $iFrom, $iTo);
     if (!$aData)

--- a/inc/classes/BxDolTwigTemplate.php
+++ b/inc/classes/BxDolTwigTemplate.php
@@ -116,11 +116,11 @@ class BxDolTwigTemplate extends BxDolModuleTemplate
         $this->pageCode (_t('_Empty'), true, false);
     }
 
-    function displayErrorOccured ()
+    function displayErrorOccurred ()
     {
         $this->pageStart();
-        echo MsgBox(_t('_Error Occured'));
-        $this->pageCode (_t('_Error Occured'), true, false);
+        echo MsgBox(_t('_Error Occurred'));
+        $this->pageCode (_t('_Error Occurred'), true, false);
     }
 
     function displayPageNotFound ()


### PR DESCRIPTION
## Summary
Fixes 5 instances of the `Occured` → `Occurred` typo across two PHP files:

1. `administration/charts.json.php` (2 instances) — JSON error responses in chart data API
2. `inc/classes/BxDolTwigTemplate.php` (3 instances) — error display function name + error message strings

## Changes
- Function name `displayErrorOccured` → `displayErrorOccurred` (line 119)
- Error message string `_Error Occured` → `_Error Occurred` (lines 122, 123)
- JSON error response `_Error Occured` → `_Error Occurred` (charts.json.php, 2 instances)

## Testing
- `php -l charts.json.php` ✅
- `php -l BxDolTwigTemplate.php` ✅

Closes #697 (resubmitted with clean commit)
